### PR TITLE
Update README.md example to latest version

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,10 +46,10 @@ Parsing and unparsing is done through functions that generate and yield instruct
 ## Example usage
 
 ```
+const { readFileSync } = require("fs");
 const {
-    parseOniSave,
-    writeOniSave,
-    getBehavior,
+    parseSaveGame,
+    writeSaveGame,
     AIAttributeLevelsBehavior
 } = require("oni-save-parser");
 


### PR DESCRIPTION
With the latest oni-save-parser (10.0.0) the README.md instructions do not work.

Also dropping getBehavior as it's not used in the example.